### PR TITLE
Fix key path handling in cloud-init scripts

### DIFF
--- a/scripts/kvm/cloud-init.sh
+++ b/scripts/kvm/cloud-init.sh
@@ -102,7 +102,7 @@ if grep -q -F -f "$PUBLIC_KEY_FILE" "$AUTHORIZED_KEYS_FILE"; then
     echo "The public key is present in the authorized_keys file."
 else
     echo "The public key is not present. Adding key to authorized_keys file..."
-    cat security/skynet-key-ecdsa.pub >>.ssh/authorized_keys
+    cat "$PUBLIC_KEY_FILE" >> "$AUTHORIZED_KEYS_FILE"
 fi
 
 # Restart SSH service to apply new settings

--- a/scripts/xen/cloud-init.sh
+++ b/scripts/xen/cloud-init.sh
@@ -105,7 +105,7 @@ if grep -q -F -f "$PUBLIC_KEY_FILE" "$AUTHORIZED_KEYS_FILE"; then
     echo "The public key is present in the authorized_keys file."
 else
     echo "The public key for ansible is not present. Adding key to authorized_keys file..."
-    cat security/skynet-key-ecdsa.pub >>.ssh/authorized_keys
+    cat "$PUBLIC_KEY_FILE" >> "$AUTHORIZED_KEYS_FILE"
 fi
 
 # Restart SSH service to apply changes


### PR DESCRIPTION
## Summary
- use key path variables for cloud-init

## Testing
- `bash -n scripts/xen/cloud-init.sh`
- `bash -n scripts/kvm/cloud-init.sh`


------
https://chatgpt.com/codex/tasks/task_e_683f4a5e0618832ca29e32e292d7d188