### PR TITLE
Fix Vagrantfile provisioning name

### DIFF
--- a/vagrant/Vagrantfile-topic-351
+++ b/vagrant/Vagrantfile-topic-351
@@ -71,8 +71,8 @@ Vagrant.configure("2") do |config|
     # STORAGE CONFIGURATION
     xen.vm.provision "shell", name: "[xen-storage]", path: "../scripts/xen/storage.sh", privileged: true
 
-    # HVM CONFIGURATION
-    xen.vm.provision "shell", name: "[xen-storage]", path: "../scripts/xen/hvm.sh", privileged: true
+  # HVM CONFIGURATION
+    xen.vm.provision "shell", name: "[xen-hvm]", path: "../scripts/xen/hvm.sh", privileged: true
 
     # LIBVIRT CONFIGURATION
     xen.vm.provision "shell", name: "[xen-libvirt]", path: "../scripts/xen/libvirt.sh", privileged: true


### PR DESCRIPTION
## Summary
- correct provisioning name for Xen HVM setup

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f49110124832ca5e2416c7177ffb3